### PR TITLE
Eliminate the gap above header images (#957)

### DIFF
--- a/web/wp-content/themes/lfevents/src/scss/components/_images.scss
+++ b/web/wp-content/themes/lfevents/src/scss/components/_images.scss
@@ -45,7 +45,6 @@ p.wp-caption-text {
   margin-inline-start: 0;
   margin-inline-end: 0;
   img {
-    width: 100%;
     object-fit: cover;
     position: absolute;
     z-index: 1;
@@ -54,7 +53,7 @@ p.wp-caption-text {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    height: auto;
+    height: 100%;
     width: 100%;
   }
 }


### PR DESCRIPTION
Issue #957 

Eliminates white gaps in mobile views of various headers. Test cases:
1. Kubecon EU FAQ: [live site](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/faq/), [PR site](https://pr-958-lfeventsci.pantheonsite.io/kubecon-cloudnativecon-europe/attend/faq/)
2. Kubecon Register: [live site](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/), [PR site](https://pr-958-lfeventsci.pantheonsite.io/kubecon-cloudnativecon-europe/register/)
3. Kubecon Ombud: [live site](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/attend/cncf-ombudsperson-mediator/)(this doesn't have a gap on most mobile widths but is included in testing), [PR site](https://pr-958-lfeventsci.pantheonsite.io/kubecon-cloudnativecon-europe/attend/cncf-ombudsperson-mediator/)